### PR TITLE
Standardize Bengali spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 [![Build Status](https://travis-ci.org/ChimeraCoder/koro.svg?branch=master)](https://travis-ci.org/ChimeraCoder/koro)
 
-#  কর
+#  করো
 
-কর (koro) is an extension of the Go compiler and toolchain to support programming in Bengali (বাংলা). 
+করো (koro) is an extension of the Go compiler and toolchain to support programming in Bengali (বাংলা). 
 
 You can read this README in [English](#english) or in [Bengali](#বাংলা).
 
-কর go কম্পাইলারের একটি এক্সটেনশন এবং বাংলা ভাষায় প্রোগ্রামিং করার  টুলচেইন। 
+করো go কম্পাইলারের একটি এক্সটেনশন এবং বাংলা ভাষায় প্রোগ্রামিং করার  টুলচেইন। 
 
 এই রিডমিটা ইংরেজি আর বাংলাতে  পড়তে পারো।
 
 
 # বাংলা
 
- কর(koro) go কম্পাইলারের একটি এক্সটেনশন এবং বাংলা ভাষায় প্রোগ্রামিং করার  টুলচেইন। 
+ করো(koro) go কম্পাইলারের একটি এক্সটেনশন এবং বাংলা ভাষায় প্রোগ্রামিং করার  টুলচেইন। 
 
 go কম্পাইলারকে যেভাবে কম্পাইল করা হয়, তেমনি ভাবেই কর কেও কম্পাইল করা যাবে। তোমার দরকার go কম্পাইলারের একটি বাইনারী কপি অথবা কর এর কোনো আগের version।
 
@@ -75,13 +75,13 @@ func main() {
 
 # English
 
- কর (koro) is an extension of the Go compiler and toolchain to support programming in Bengali (বাংলা).
+ করো (koro) is an extension of the Go compiler and toolchain to support programming in Bengali (বাংলা).
 
 
 
-## Building the কর toolchain
+## Building the করো toolchain
 
-Compiling কর is similar to compiling the Go compiler from scratch. You will need either a binary copy of the Go compiler (version 1.4 or higher), or a previous version of কর. 
+Compiling করো is similar to compiling the Go compiler from scratch. You will need either a binary copy of the Go compiler (version 1.4 or higher), or a previous version of করো 
 
 ```sh
 $ cd src/
@@ -89,9 +89,9 @@ $ ./all.bash
 ```
 
 This will create two files in `bin/` - one named `go` and one named `gofmt`. It is recommended to rename or symlink these to `koro` and `korofmt` before adding them to your path to avoid confusion; however, these can be used to compile English Go code as well.
-## Writing in কর
+## Writing in করো
 
-The syntax of কর is exactly the same as the syntax of English Go, except that Bengali keywords are valid syntax. The full list of Bengali কর keywords is:
+The syntax of করো is exactly the same as the syntax of English Go, except that Bengali keywords are valid syntax. The full list of Bengali করো keywords is:
 
  `ভাঙ্গা`, `ক্ষেত্রে`, 	`চ্যানেল`, `ধ্রুবক`, `চলো`, 	`ডিফল্ট`, `মুলতবি`, `অন্যভাবে`, `নির্ঝর`, `যখনই`,`ফ`, `কর`,`লাফ`,`যদি`,`আমদানি`,`ইন্টারফেস`,`অভিধান`,`প্যাকেজ`,`প্রতিটি`,`ফিরুন`,`নির্বাচন`, `গঠন`, `সুইচ`,`ধরনের`, `পরিবর্তনশীল`
 
@@ -110,17 +110,17 @@ For example, this is a "Hello, world" program:
 }
 ```
 
-Running your program works identically to the English Go compiler -`go build`, `go run`, etc. Assuming you have named your কর compiler as `koro`, you can run this program with:
+Running your program works identically to the English Go compiler -`go build`, `go run`, etc. Assuming you have named your করো compiler as `koro`, you can run this program with:
 
 ```sh
 $ koro run koro_hello_world.go
 ```
 
 
-## Translating কর to English Go
+## Translating করো to English Go
 
 
-To translate কর code into English, simply run `korofmt`. The flags are identical to `gofmt`. For example:
+To translate করো code into English, simply run `korofmt`. The flags are identical to `gofmt`. For example:
 
 
 
@@ -145,6 +145,6 @@ func main() {
 
 ## Contributions
 
-Contributions welcome. And most importantly, মজা কর!
+Contributions welcome. And most importantly, মজা করো!
 
 ![Gopher image](doc/gopher/biplane.jpg)


### PR DESCRIPTION
কর -> করো

Both are used, but করো is technically the preferred spelling.